### PR TITLE
Add Apache header to package init

### DIFF
--- a/src/wavlmmsdd/__init__.py
+++ b/src/wavlmmsdd/__init__.py
@@ -1,0 +1,21 @@
+"""WavLM-MSDD: A toolkit for speaker diarization using WavLM embeddings.
+
+This package provides utilities and models for segmenting audio by speaker
+leveraging WavLM embeddings and multi-stage diarization.
+"""
+
+# Copyright 2025 Bunyamin Ergen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = []


### PR DESCRIPTION
## Summary
- add Apache 2.0 copyright notice and description in `src/wavlmmsdd/__init__.py`

## Testing
- `ruff check .`
- `pytest -q` *(fails: unrecognized arguments `--cov=src` because pytest-cov isn't installed)*