### PR TITLE
Replace prints with logging

### DIFF
--- a/src/wavlmmsdd/audio/diarization/diarize.py
+++ b/src/wavlmmsdd/audio/diarization/diarize.py
@@ -9,6 +9,9 @@ from omegaconf import OmegaConf
 
 # Local imports
 from wavlmmsdd.audio.feature.embedding import WavLMSV
+from wavlmmsdd.utils.logger import get_logger
+
+LOG = get_logger(__name__)
 
 
 class Diarizer:
@@ -109,7 +112,7 @@ class Diarizer:
 
         """
         self.clustering_diarizer.diarize()
-        print('Diarization Completed!')
+        LOG.info('Diarization Completed!')
 
 
 if __name__ == '__main__':

--- a/src/wavlmmsdd/audio/feature/embedding.py
+++ b/src/wavlmmsdd/audio/feature/embedding.py
@@ -8,6 +8,10 @@ from omegaconf import DictConfig, OmegaConf
 from torch import Tensor
 from transformers import Wav2Vec2FeatureExtractor, WavLMForXVector
 
+from wavlmmsdd.utils.logger import get_logger
+
+LOG = get_logger(__name__)
+
 
 class WavLMSV:
     """WavLMSV is a class designed to load a WavLM XVector model from the
@@ -96,7 +100,7 @@ class WavLMSV:
         device_option = device_list[0]
 
         if device_option == 'cuda' and not torch.cuda.is_available():
-            print('[WARNING] CUDA is not available. Falling back to CPU.')
+            LOG.warning('CUDA is not available. Falling back to CPU.')
             device_option = 'cpu'
 
         self.device = device_option
@@ -109,13 +113,13 @@ class WavLMSV:
                 f'Allowed models are: {allowed_models}'
             )
 
-        print(f'[INFO] Loading XVector model: {model_name} on device: {self.device}')
+        LOG.info('Loading XVector model: %s on device: %s', model_name, self.device)
         self.feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained(model_name)
         self.model = WavLMForXVector.from_pretrained(model_name).to(self.device)
         self.model.eval()
 
         self.xvector_dim = self.model.config.xvector_output_dim
-        print(f'[INFO] XVector dimension: {self.xvector_dim}')
+        LOG.info('XVector dimension: %d', self.xvector_dim)
 
     def extract(
         self,

--- a/src/wavlmmsdd/audio/preprocess/convert.py
+++ b/src/wavlmmsdd/audio/preprocess/convert.py
@@ -7,6 +7,10 @@ from typing import Annotated
 import torch
 import torchaudio
 
+from wavlmmsdd.utils.logger import get_logger
+
+LOG = get_logger(__name__)
+
 
 class Convert:
     """Convert is a class for converting an audio waveform to mono
@@ -204,7 +208,7 @@ class Convert:
         os.makedirs(dir_name, exist_ok=True)
 
         torchaudio.save(output_path, self.waveform, self.sample_rate)
-        print(f'[Convert.save] 16k+mono file saved: {output_path}')
+        LOG.info('16k+mono file saved: %s', output_path)
         return output_path
 
 
@@ -213,11 +217,11 @@ if __name__ == '__main__':
     test_converter = Convert(audio_file=audio)
     test_converter.to_mono()
     output = test_converter.save()
-    print(f'Saved file: {output}')
+    LOG.info('Saved file: %s', output)
 
     test_waveform = torch.randn(2, 48000)
     rate = 48000
     converter_direct = Convert(waveform=test_waveform, sample_rate=rate)
     converter_direct.to_mono()
     output_path_direct = converter_direct.save('.temp/mono_example.wav')
-    print(f'Saved file: {output_path_direct}')
+    LOG.info('Saved file: %s', output_path_direct)

--- a/src/wavlmmsdd/audio/preprocess/resample.py
+++ b/src/wavlmmsdd/audio/preprocess/resample.py
@@ -5,6 +5,10 @@ from typing import Annotated
 import torch
 import torchaudio
 
+from wavlmmsdd.utils.logger import get_logger
+
+LOG = get_logger(__name__)
+
 
 class Resample:
     """Resample is a class for converting an audio waveform to 16 kHz.
@@ -144,10 +148,18 @@ if __name__ == '__main__':
 
     resample_instance = Resample(audio_file=audio)
     test_new_waveform, test_new_sr = resample_instance.to_16k()
-    print(f'Resampled waveform shape: {test_new_waveform.shape}, sample rate: {test_new_sr}')
+    LOG.info(
+        'Resampled waveform shape: %s, sample rate: %s',
+        test_new_waveform.shape,
+        test_new_sr,
+    )
 
     test_wave = torch.randn(1, 32000)
     test_sr: int = 48000
     test_resample_instance = Resample(waveform=test_wave, sample_rate=test_sr)
     new_waveform_test, new_sr_test = resample_instance.to_16k()
-    print(f'Resampled waveform shape: {new_waveform_test.shape}, sample rate: {new_sr_test}')
+    LOG.info(
+        'Resampled waveform shape: %s, sample rate: %s',
+        new_waveform_test.shape,
+        new_sr_test,
+    )

--- a/src/wavlmmsdd/utils/logger.py
+++ b/src/wavlmmsdd/utils/logger.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Bunyamin Ergen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logging utilities for wavlmmsdd."""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger configured with basic settings."""
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- add shared logger utility
- use the logger in embedding, convert, resample and diarize modules

## Testing
- `ruff check src/wavlmmsdd/utils/logger.py src/wavlmmsdd/audio/feature/embedding.py src/wavlmmsdd/audio/preprocess/convert.py src/wavlmmsdd/audio/preprocess/resample.py src/wavlmmsdd/audio/diarization/diarize.py`
- `pytest -q` *(fails: unrecognized arguments --cov=src --cov-report=term-missing)*